### PR TITLE
Fix subject

### DIFF
--- a/.github/chainguard/datadog-cdk-constructs.release.sts.yaml
+++ b/.github/chainguard/datadog-cdk-constructs.release.sts.yaml
@@ -1,6 +1,6 @@
 # https://datadoghq.atlassian.net/wiki/spaces/SECENG/pages/5138645099/User+guide+dd-octo-sts
 issuer: https://gitlab.ddbuild.io
-subject: project_path:DataDog/datadog-cdk-constructs:*
+subject_pattern: project_path:DataDog/datadog-cdk-constructs:*
 
 claim_pattern:
   project_id: "1776"


### PR DESCRIPTION
# Notes
Subject takes the literal string, while we want any ref on the project which requires we use subject_path.  This currently only allows a ref of `*` which means I'm getting a [403](https://gitlab.ddbuild.io/DataDog/datadog-cdk-constructs/-/jobs/1138169425#L124).

[dd-octo-sts user guide](https://datadoghq.atlassian.net/wiki/spaces/SECENG/pages/5138645099/User+guide+dd-octo-sts)